### PR TITLE
Update StringTableEnSymptoms.xml

### DIFF
--- a/localization-proofreading-english/StringTableEnSymptoms.xml
+++ b/localization-proofreading-english/StringTableEnSymptoms.xml
@@ -667,21 +667,21 @@
             <GameDBLocalizedString>      <LocID>SYM_GASTRITIS_DISCOVERED</LocID>                            <Text>Gastritis discovered</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>SYM_GASTRITIS_DISCOVERED_DESCRIPTION</LocID>                <Text>Gastroscopy has discovered a large gastric inflammation.</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>SYM_GIANT_CELLS</LocID>                                     <Text>Giant cells</Text>  </GameDBLocalizedString>
-            <GameDBLocalizedString>      <LocID>SYM_GIANT_CELLS_DESCRIPTION</LocID>                         <Text>Angiography has revealed the presence of inflammation of the lining of temporal arteries.</Text>  </GameDBLocalizedString>
+            <GameDBLocalizedString>      <LocID>SYM_GIANT_CELLS_DESCRIPTION</LocID>                         <Text>Angiography has revealed inflammation in the lining of the temporal arteries.</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>SYM_GIARDIA_LAMBLIA_DISCOVERED</LocID>                      <Text>Giardia lamblia detected</Text>  </GameDBLocalizedString>
-            <GameDBLocalizedString>      <LocID>SYM_GIARDIA_LAMBLIA_DISCOVERED_DESCRIPTION</LocID>          <Text>Bacterial cultivation detected Giardia lamblia in patient's stool sample.</Text>  </GameDBLocalizedString>
+            <GameDBLocalizedString>      <LocID>SYM_GIARDIA_LAMBLIA_DISCOVERED_DESCRIPTION</LocID>          <Text>Bacterial cultivation has detected Giardia lamblia in the patient's stool sample.</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>SYM_GRANULOMAS_EYES</LocID>                                 <Text>Granulomas - eyes</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>SYM_GRANULOMAS_EYES_DESCRIPTION</LocID>                     <Text>Special eye exam has revealed granulomas affecting the eyes.</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>SYM_GRANULOMAS_HEART</LocID>                                <Text>Granulomas - heart</Text>  </GameDBLocalizedString>
-            <GameDBLocalizedString>      <LocID>SYM_GRANULOMAS_HEART_DESCRIPTION</LocID>                    <Text>MRI examination has revealed granulomas affecting the heart.</Text>  </GameDBLocalizedString>
+            <GameDBLocalizedString>      <LocID>SYM_GRANULOMAS_HEART_DESCRIPTION</LocID>                    <Text>MRI has revealed granulomas affecting the heart.</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>SYM_GRANULOMAS_LUNGS</LocID>                                <Text>Granulomas - lungs</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>SYM_GRANULOMAS_LUNGS_DESCRIPTION</LocID>                    <Text>X-ray imaging has revealed granulomas affecting lungs.</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>SYM_GUILLAIN-BARRE_FINDINGS</LocID>                         <Text>Guillain-Barre findings</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>SYM_GUILLAIN-BARRE_FINDINGS_DESCRIPTION</LocID>             <Text>Spinal fluid analysis has revealed multiple signs of Guillain-Barre syndrome.</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>SYM_H._PYLORI_DETECTED</LocID>                              <Text>H. pylori detected</Text>  </GameDBLocalizedString>
-            <GameDBLocalizedString>      <LocID>SYM_H._PYLORI_DETECTED_DESCRIPTION</LocID>                  <Text>Technologists discovered specific antibodies related to Helicobacter pylori.</Text>  </GameDBLocalizedString>
-            <GameDBLocalizedString>      <LocID>SYM_HAND_BURSAE_INFLAMMED</LocID>                           <Text>Hand bursae inflamed</Text>  </GameDBLocalizedString>
-            <GameDBLocalizedString>      <LocID>SYM_HAND_BURSAE_INFLAMMED_DESCRIPTION</LocID>               <Text>Ultrasonography has discovered inflammation of bursae in patient's hand.</Text>  </GameDBLocalizedString>
+            <GameDBLocalizedString>      <LocID>SYM_H._PYLORI_DETECTED_DESCRIPTION</LocID>                  <Text>Tests found specific antibodies related to Helicobacter pylori.</Text>  </GameDBLocalizedString>
+            <GameDBLocalizedString>      <LocID>SYM_HAND_BURSAE_INFLAMMED</LocID>                           <Text>Inflamed hand bursae</Text>  </GameDBLocalizedString>
+            <GameDBLocalizedString>      <LocID>SYM_HAND_BURSAE_INFLAMMED_DESCRIPTION</LocID>               <Text>Ultrasonography has discovered inflammation of the bursae in the patient's hand.</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>SYM_HAND_PENETRATION</LocID>                                <Text>Hand penetrated</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>SYM_HAND_PENETRATION_DESCRIPTION</LocID>                    <Text>Penetration of a hand caused a deep wound.</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>SYM_HAPTOGLOBIN_HIGH</LocID>                                <Text>Haptoglobin - high level</Text>  </GameDBLocalizedString>


### PR DESCRIPTION
670 - rephrased "Angiography has revealed the presence of inflammation of the lining of temporal arteries" to "Angiography has revealed inflammation in the lining of the temporal arteries"
674 - added 'has' and 'the' to "Baceterial cultivation has detected Giardia lamblia in the patient's stool sample"
676 - removed 'examination' from "MRI examination ..."
682 - Replaced 'technologists' with 'tests' and 'discovered' with 'found'
683 - Rephrased.