### PR TITLE
Fixed headers of several Danish files

### DIFF
--- a/localization-pack-da/StringTableDaAchievements.xml
+++ b/localization-pack-da/StringTableDaAchievements.xml
@@ -1,8 +1,8 @@
 ﻿<Database>
-    <GameDBStringTable ID="LOC_EN_ACHIEVEMENTS">
+    <GameDBStringTable ID="LOC_DA_ACHIEVEMENTS">
         
-        <LanguageCode>en</LanguageCode>
-        <LanguageNameLocalized>English</LanguageNameLocalized>
+        <LanguageCode>da</LanguageCode>
+        <LanguageNameLocalized>Dansk</LanguageNameLocalized>
 
         <Contributors>
             <Name>Oxymoron Games</Name>

--- a/localization-pack-da/StringTableDaDiagnoses.xml
+++ b/localization-pack-da/StringTableDaDiagnoses.xml
@@ -1,8 +1,8 @@
 ﻿<Database>
-    <GameDBStringTable ID="LOC_EN_DIAGNOSES">
+    <GameDBStringTable ID="LOC_DA_DIAGNOSES">
         
-        <LanguageCode>en</LanguageCode>
-        <LanguageNameLocalized>English</LanguageNameLocalized>
+        <LanguageCode>da</LanguageCode>
+        <LanguageNameLocalized>Dansk</LanguageNameLocalized>
 
         <Contributors>
             <Name>Oxymoron Games</Name>

--- a/localization-pack-da/StringTableDaExaminations.xml
+++ b/localization-pack-da/StringTableDaExaminations.xml
@@ -1,8 +1,8 @@
 ﻿<Database>
-    <GameDBStringTable ID="LOC_EN_EXAMINATIONS">
+    <GameDBStringTable ID="LOC_DA_EXAMINATIONS">
 
-        <LanguageCode>en</LanguageCode>
-        <LanguageNameLocalized>English</LanguageNameLocalized>
+        <LanguageCode>da</LanguageCode>
+        <LanguageNameLocalized>Dansk</LanguageNameLocalized>
 
         <Contributors>
             <Name>Oxymoron Games</Name>

--- a/localization-pack-da/StringTableDaSymptoms.xml
+++ b/localization-pack-da/StringTableDaSymptoms.xml
@@ -1,8 +1,8 @@
 ﻿<Database>
-    <GameDBStringTable ID="LOC_EN_SYMPTOMS">
+    <GameDBStringTable ID="LOC_DA_SYMPTOMS">
         
-        <LanguageCode>en</LanguageCode>
-        <LanguageNameLocalized>English</LanguageNameLocalized>
+        <LanguageCode>da</LanguageCode>
+        <LanguageNameLocalized>Dansk</LanguageNameLocalized>
 
         <Contributors>
             <Name>Oxymoron Games</Name>

--- a/localization-pack-da/StringTableDaTreatments.xml
+++ b/localization-pack-da/StringTableDaTreatments.xml
@@ -1,8 +1,8 @@
 ﻿<Database>
-    <GameDBStringTable ID="LOC_EN_TREATMENTS">
+    <GameDBStringTable ID="LOC_DA_TREATMENTS">
         
-        <LanguageCode>en</LanguageCode>
-        <LanguageNameLocalized>English</LanguageNameLocalized>
+        <LanguageCode>da</LanguageCode>
+        <LanguageNameLocalized>Dansk</LanguageNameLocalized>
 
         <Contributors>
             <Name>Oxymoron Games</Name>

--- a/localization-pack-da/StringTableDaTutorial.xml
+++ b/localization-pack-da/StringTableDaTutorial.xml
@@ -1,8 +1,8 @@
-﻿<Database>
-    <GameDBStringTable ID="LOC_EN_TUTORIAL">
+<Database>
+    <GameDBStringTable ID="LOC_DA_TUTORIAL">
         
-        <LanguageCode>en</LanguageCode>
-        <LanguageNameLocalized>English</LanguageNameLocalized>
+        <LanguageCode>da</LanguageCode>
+        <LanguageNameLocalized>Dansk</LanguageNameLocalized>
 
         <Contributors>
             <Name>Oxymoron Games</Name>


### PR DESCRIPTION
Note: Files in language packs that have language code set to English override the actual English texts in game.