### PR TITLE
Change of wording "Praktikant"

### DIFF
--- a/localization-pack-de/StringTableDeUI.xml
+++ b/localization-pack-de/StringTableDeUI.xml
@@ -748,7 +748,7 @@
             <GameDBLocalizedString>      <LocID>MANAGEMENT_BUDGET_EVENTS</LocID>            <Text>Ereignisse</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>MANAGEMENT_BUDGET_AMBULANCES</LocID>        <Text>Krankenwagen</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>MANAGEMENT_BUDGET_OTHER</LocID>             <Text>Andere</Text>  </GameDBLocalizedString>
-            <GameDBLocalizedString>      <LocID>GET_GREAT_INTERNS</LocID>                   <Text>Der / die nächste(n) {1} Praktikant(en) sind bereit übernommen zu werden. Es wird ein / werden gute(r) Kandidat(en)!</Text>  </GameDBLocalizedString>
+            <GameDBLocalizedString>      <LocID>GET_GREAT_INTERNS</LocID>                   <Text>Der / die nächste(n) {1} Assistenzarzt/-ärzte sind bereit übernommen zu werden. Es wird ein / werden gute(r) Kandidat(en)!</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>EVENT_BONUS</LocID>                         <Text>Ereignisboni:</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>TOOLTIP_DEPARTMENT_TOTAL_STAFF</LocID>      <Text>Eingestelle Mitarbeiter / Gesamtlimit</Text>  </GameDBLocalizedString>
             <GameDBLocalizedString>      <LocID>MONEY_BONUS</LocID>                         <Text>Extrazahlungen:</Text>  </GameDBLocalizedString>


### PR DESCRIPTION
The german term "Praktikant" is a wrong translation of "Intern". Concerning the healthcare in german, a appropriate translation is "Assistenzarzt".